### PR TITLE
Fix GitHub Action dependency installation issue

### DIFF
--- a/.github/workflows/update-vector-database.yml
+++ b/.github/workflows/update-vector-database.yml
@@ -29,12 +29,8 @@ jobs:
         
     - name: Install dependencies
       run: |
-        # Try to install from pyproject.toml first, fallback to manual installation
-        if [ -f "pyproject.toml" ]; then
-          uv pip install --system .
-        else
-          uv pip install --system langchain langchain-openai langchain-community qdrant-client python-dotenv PyPDF2 langchain-text-splitters
-        fi
+        # Install only the dependencies, not the project itself
+        uv pip install --system langchain langchain-openai langchain-community qdrant-client python-dotenv PyPDF2 langchain-text-splitters
         
     - name: Validate required secrets
       run: |


### PR DESCRIPTION
- Remove attempt to install local project as package
- Install only required dependencies directly
- Fix investigator-ai==0.1.0 unsatisfiable requirement error
- Update actions/upload-artifact from v3 to v4 to resolve deprecation warning